### PR TITLE
添加flask lint 脚本,可自动format代码格式

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,14 +1,19 @@
 # @Time    : 2019-06-01 08:09
 # @Author  : __apple
 import sys
+from .app import Flask
 from base import log
 from base.log import start_log
-from .app import Flask
+from cmds import lint
 
 
 def register_blueprints(app):
     from app.api.v1 import create_blueprint_v1
     app.register_blueprint(create_blueprint_v1(), url_prefix='/v1')
+
+
+def register_cmd(app):
+    app.cli.add_command(lint.lint)
 
 
 def register_plugin(app):
@@ -28,6 +33,7 @@ def create_app():
     app = Flask(__name__)
     app.config.from_object('config.config')
     register_blueprints(app)
+    register_cmd(app)
     register_plugin(app)
     startup_log()
     return app

--- a/cmds/lint.py
+++ b/cmds/lint.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+import click
+import datetime
+import json
+import os
+from config.config import CONFIG_DIR
+
+__all__ = ['lint']
+
+ignore_dir = [
+    'static',
+    'templates',
+    'image_temp',
+    'website',
+    'migrations',
+    'node_modules',
+    'venv',
+    '__pycache__'
+]
+
+
+def f_code(path, md5_dict):
+    md5 = os.popen("md5sum {0}|cut -d ' ' -f1".format(path)).read().strip()
+    if md5_dict.get(path, None) != md5:
+        print(path)
+        os.system('isort -e -ns __init__.py -sl -ds -w 80 ' + path)
+        os.system('autopep8 --in-place --aggressive --aggressive ' + path)
+        md5_dict[path] = os.popen(
+            "md5sum {0}|cut -d ' ' -f1".format(path)).read().strip()
+
+
+def read_dir(path, md5_dict):
+    result = []
+    for d in os.listdir(path):
+        if d not in ignore_dir:
+            sub_path = os.path.join(path, d)
+            if os.path.isdir(sub_path):
+                result += read_dir(sub_path, md5_dict)
+            elif sub_path[-3:] == '.py':
+                f_code(sub_path, md5_dict)
+    return result
+
+
+@click.command()
+def lint():
+    base_path = CONFIG_DIR
+    print(base_path)
+    print(datetime.datetime.now())
+    md5_dict = {}
+    if not os.path.exists(os.path.join(base_path, '.pymd5')):
+        with open(os.path.join(base_path, '.pymd5'), 'w+') as f:
+            f.write(json.dumps(md5_dict))
+    with open(os.path.join(base_path, '.pymd5'), 'r+') as f:
+        md5_dict = json.loads(f.read())
+        read_dir(base_path, md5_dict)
+
+    with open(os.path.join(base_path, '.pymd5'), 'w+') as f:
+        f.write(json.dumps(md5_dict))
+    print(datetime.datetime.now())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp==3.6.2
 async-timeout==3.0.1
 attrs==19.3.0
+autopep8==1.4.4
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0
@@ -9,6 +10,7 @@ Flask==1.1.1
 Flask-HTTPAuth==3.3.0
 Flask-SQLAlchemy==2.4.1
 idna==2.8
+isort==4.3.21
 itsdangerous==1.1.0
 jieba==0.41
 Jinja2==2.10.3


### PR DESCRIPTION
如题 
flask lint
使用isort库和autopep8库对项目代码进行格式化
建议每次commit前在项目环境中执行flask lint